### PR TITLE
Allow server to be launched after the game | Fix typo in save path

### DIFF
--- a/hooks/src/uplay_r1_loader/save.rs
+++ b/hooks/src/uplay_r1_loader/save.rs
@@ -327,7 +327,7 @@ trait SaveGame {
 
 impl SaveGame for Save {
     fn get_savegames_path(&self) -> PathBuf {
-        const SAVE_GAME_FOLDER: &str = "5th-Echolon\\Saves";
+        const SAVE_GAME_FOLDER: &str = "5th-Echelon\\Saves";
         match self.save_dir {
             crate::config::SaveDir::InstallLocation => todo!(),
             crate::config::SaveDir::Roaming => known_folder_roaming_app_data()


### PR DESCRIPTION
Replaced `api::login` with a loop, fixed typo in saves path.