### PR TITLE
Add note about IPs in service.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ similar for previous games as well.
 
 1. Start the server `dedicated_server.exe`
 2. Note the (public) IP address of the server (like your VPN IP if you're using radmin/hamachi)
+3. Open `service.toml` file and change all Values, secure_server_addr, storage_host, from 127.0.0.1 to your address from step 2
 3. Make sure the ports tcp/80, tcp/50051, tcp/8000, udp/21120 and udp/21127 are open to your peers (allowed in firewall or firewall off)
 
 ### On the clients (all players who want to connect to the community server)


### PR DESCRIPTION
Values, secure_server_addr and storage_host are set to 127.0.0.1 by default, but should be set to the public ip of the host. I added explanation about fixing it in README.md file.

P.S. I have some questions about running 5th-echelon from linux. Sent a mail with explanation and all log files to your e-mail.