### PR TITLE
"ERRO recv_from failed" errors in console

### DIFF
--- a/quazal/src/prudp.rs
+++ b/quazal/src/prudp.rs
@@ -128,7 +128,9 @@ where
             let (nread, client) = match socket.recv_from(&mut buf) {
                 Ok(x) => x,
                 Err(e) => {
-                    if e.kind() == std::io::ErrorKind::TimedOut {
+                    if e.kind() == std::io::ErrorKind::TimedOut
+                        || e.kind() == std::io::ErrorKind::WouldBlock
+                    {
                         self.clear_clients();
                     } else {
                         error!(self.logger, "recv_from failed: {}", e);


### PR DESCRIPTION
when i run the dedicated server on linux, i get these errors every second:
```
  Oct 06 19:53:31.840 ERRO recv_from failed: Resource temporarily unavailable (os error 11)
 service: sc_bl_secure
  Oct 06 19:53:31.840 ERRO recv_from failed: Resource temporarily unavailable (os error 11)
 service: sc_bl_auth
  Oct 06 19:53:32.854 ERRO recv_from failed: Resource temporarily unavailable (os error 11)
 service: sc_bl_secure
  Oct 06 19:53:32.854 ERRO recv_from failed: Resource temporarily unavailable (os error 11)
```

server code was checking for TimedOut error, but it is returned only on windows. after adding check for WouldBlock, server log becomes clean (but i think those errors were harmless)