### PR TITLE
fix: SanboxUrlWS address automatic config

### DIFF
--- a/quazal/src/config.rs
+++ b/quazal/src/config.rs
@@ -242,7 +242,7 @@ impl OnlineConfig {
                             value.push_str(&rest[end_idx - start_idx..]);
                         }
                     }
-					if item.name == "SandboxUrlWS" {
+                    if item.name == "SandboxUrlWS" {
                         for value in &mut item.values {
                             if let Ok(mut addr) = value.parse::<SocketAddr>() {
                                 addr.set_ip(public_ip);


### PR DESCRIPTION
# Issue

When you run the server with the launcher to configure it automatically, the `SandboxUrlWS` address is not changing, so you still need to change it manually. 

## Fixing

Added SandboxUrlWS handling in the `config.rs`

Before:
![image](https://github.com/user-attachments/assets/c5820eae-3f57-480f-bef6-7d2cf884359f)

After:
![image](https://github.com/user-attachments/assets/bd33e682-11a1-4e27-ad02-4cd760fa7eb7)
